### PR TITLE
containered|runc: override GOROOT at build time

### DIFF
--- a/recipes-containers/containerd/containerd_git.bb
+++ b/recipes-containers/containerd/containerd_git.bb
@@ -44,6 +44,7 @@ do_compile() {
 	mkdir -p .gopath/src/"$(dirname "${CONTAINERD_PKG}")"
 	ln -sf ../../../.. .gopath/src/"${CONTAINERD_PKG}"
 	export GOPATH="${S}/.gopath:${S}/vendor:${STAGING_DIR_TARGET}/${prefix}/local/go"
+	export GOROOT="${STAGING_DIR_NATIVE}/${nonarch_libdir}/${HOST_SYS}/go"
 	cd -
 
 	# Pass the needed cflags/ldflags so that cgo

--- a/recipes-containers/runc/runc_git.bb
+++ b/recipes-containers/runc/runc_git.bb
@@ -43,6 +43,7 @@ do_compile() {
 
 	(cd .gopath/src/${dname}; ln -sf ../../../../../${bname} ${bname})
 	export GOPATH="${S}/.gopath:${S}/vendor:${STAGING_DIR_TARGET}/${prefix}/local/go"
+	export GOROOT="${STAGING_DIR_NATIVE}/${nonarch_libdir}/${HOST_SYS}/go"
 	cd -
 
 	# Pass the needed cflags/ldflags so that cgo


### PR DESCRIPTION
Similar to commit 01aa8f1, runc and containered also need to set GOROOT
explicitly.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>